### PR TITLE
export KubeContext, allow non global use

### DIFF
--- a/src/Kuber.jl
+++ b/src/Kuber.jl
@@ -16,7 +16,7 @@ include("typealiases.jl")
 include("helpers.jl")
 include("simpleapi.jl")
 
-export set_server, set_ns, kuber_type, kuber_obj, @K_str
+export KuberContext, set_server, set_ns, kuber_type, kuber_obj, @K_str
 export ComponentStatus, Endpoints, Namespace, Pod, PodTemplate, ReplicationController, Service, PersistentVolume, PersistentVolumeClaim, Job, Secret
 export get, put!, update!, delete!, sel
 

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -49,16 +49,14 @@ end
 
 const _global_ctx = KuberContext()
 
-function set_server(uri::String=DEFAULT_URI; kwargs...)
-    global _global_ctx
+set_server(uri::String=DEFAULT_URI; kwargs...) = set_server(_global_ctx, uri; kwargs...)
+function set_server(ctx::KuberContext, uri::String=DEFAULT_URI; kwargs...)
     client = Swagger.Client(uri; get_return_type=kuber_type, kwargs...)
-    _global_ctx.api = DefaultApi(client)
+    ctx.api = DefaultApi(client)
 end
 
-function set_ns(namespace::String)
-    global _global_ctx
-    _global_ctx.namespace = namespace
-end
+set_ns(namespace::String) = set_ns(_global_ctx, namespace)
+set_ns(ctx::KuberContext, namespace::String) = (ctx.namespace = namespace)
 
 # generate easy wrappers
 for fn in (:get, :put!, :update!, :delete!)


### PR DESCRIPTION
- export `KubeContext`
- allow an instance to be passed to `set_server` and `set_ns`