### PR TITLE
update code generator to use CSTParser v2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ os:
 julia:
   - 1.0
   - 1.1
+  - 1.2
+  - 1.3
   - nightly
 matrix:
   allow_failures:

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,25 @@
+name = "Kuber"
+uuid = "87e52247-8a1b-5e01-9430-8fbcac83a23a"
+authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
+keywords = ["kubernetes", "client"]
+license = "MIT"
+desc = "Julia Kubernetes Client"
+version = "0.2.2"
+
+[deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Swagger = "2d69052b-6a58-5cd9-a030-a48559c324ac"
+
+[compat]
+HTTP = "~ 0.8"
+Swagger = "~ 0.2"
+julia = "~ 1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,0 @@
-julia 1.0
-HTTP 0.8.0
-JSON
-Swagger 0.2.0

--- a/gen/generate.sh
+++ b/gen/generate.sh
@@ -5,6 +5,7 @@ if [ $# -ne 1 ]; then
     echo "Ensure:"
     echo "  - 'julia' is in PATH or set in environment variable 'JULIA'."
     echo "  - package directory is writable."
+    echo "  - CSTParser v2.1.0 is installed."
     echo "Note:"
     echo "  - your current 'src/api' folder in the package will be renamed to 'src/api_bak'"
     echo "  - existing 'src/api_bak' folder if any will be deleted"
@@ -18,6 +19,14 @@ if [ -z "$JULIA" ]
 then
     JULIA=julia
 fi
+
+# ensure CSTParser is of right version
+cstpver=`${JULIA} -e 'println(Pkg.installed()["CSTParser"] == v"2.1.0")'`
+if [ "$cstpver" != "true" ]
+then
+    echo "CSTParser v2.1.0 is required"
+    exit -1
+end
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 GENDIR="$( readlink -e "${DIR}/../" )"


### PR DESCRIPTION
- update code generator to use CSTParser v2.1.0
- update travis configuration
- add a Project.toml, delete REQUIRE file, bump version to v0.2.2