### PR TITLE
support other api versions

### DIFF
--- a/src/simpleapi.jl
+++ b/src/simpleapi.jl
@@ -9,11 +9,21 @@ sel(cnd::String...) = join(cnd, ", ")
 
 _delopts(; kwargs...) = Typedefs.MetaV1.DeleteOptions(; preconditions=Typedefs.MetaV1.Preconditions(; kwargs...), kwargs...)
 
-function list(ctx::KuberContext, O::Symbol, name::String; namespace::Union{String,Nothing}=ctx.namespace, kwargs...)
+function _get_apictx(ctx::KuberContext, O::Symbol, apiversion::Union{String,Nothing})
+    if apiversion != nothing
+        k = Kuber.api_group_type(apiversion)
+        apictx = k(ctx.client)
+    else
+        kapi = ctx.modelapi[O]
+        apictx = kapi.api(ctx.client)
+    end
+    apictx
+end
+
+function list(ctx::KuberContext, O::Symbol, name::String, apiversion::Union{String,Nothing}=nothing; namespace::Union{String,Nothing}=ctx.namespace, kwargs...)
     isempty(ctx.apis) && set_api_versions!(ctx)
 
-    kapi = ctx.modelapi[O]
-    apictx = kapi.api(ctx.client)
+    apictx = _get_apictx(ctx, O, apiversion)
     namespaced = (namespace !== nothing) && !isempty(namespace)
     allnamespaces = namespaced && (namespace == "*")
 
@@ -29,11 +39,10 @@ function list(ctx::KuberContext, O::Symbol, name::String; namespace::Union{Strin
     end
 end
 
-function list(ctx::KuberContext, O::Symbol; namespace::Union{String,Nothing}=ctx.namespace, kwargs...)
+function list(ctx::KuberContext, O::Symbol, apiversion::Union{String,Nothing}=nothing; namespace::Union{String,Nothing}=ctx.namespace, kwargs...)
     isempty(ctx.apis) && set_api_versions!(ctx)
 
-    kapi = ctx.modelapi[O]
-    apictx = kapi.api(ctx.client)
+    apictx = _get_apictx(ctx, O, apiversion)
     namespaced = (namespace !== nothing) && !isempty(namespace)
     allnamespaces = namespaced && (namespace == "*")
 
@@ -49,21 +58,10 @@ function list(ctx::KuberContext, O::Symbol; namespace::Union{String,Nothing}=ctx
     end
 end
 
-function get(ctx::KuberContext, O::Symbol, name::String; kwargs...)
+function get(ctx::KuberContext, O::Symbol, name::String, apiversion::Union{String,Nothing}=nothing; kwargs...)
     isempty(ctx.apis) && set_api_versions!(ctx)
-    d = Dict(kwargs)
 
-    if haskey(d, :apiVersion)
-        v = d[:apiVersion]
-        k = Kuber.api_group_type(v)
-        apictx = k(ctx.client)
-        delete!(d, :apiVersion)
-        kwargs = d
-    else
-        kapi = ctx.modelapi[O]
-        apictx = kapi.api(ctx.client)
-    end
-
+    apictx = _get_apictx(ctx, O, apiversion)
     try
         apicall = eval(Symbol("read$O"))
         return apicall(apictx, name; kwargs...)
@@ -74,12 +72,10 @@ function get(ctx::KuberContext, O::Symbol, name::String; kwargs...)
     end
 end
 
-function get(ctx::KuberContext, O::Symbol; label_selector=nothing, namespace::Union{String,Nothing}=ctx.namespace)
+function get(ctx::KuberContext, O::Symbol, apiversion::Union{String,Nothing}=nothing; label_selector=nothing, namespace::Union{String,Nothing}=ctx.namespace)
     isempty(ctx.apis) && set_api_versions!(ctx)
 
-    kapi = ctx.modelapi[O]
-    apictx = kapi.api(ctx.client)
-
+    apictx = _get_apictx(ctx, O, apiversion)
     try
         apiname = "list$O"
         (namespace === nothing) && (apiname *= "ForAllNamespaces")
@@ -101,15 +97,7 @@ end
 function put!(ctx::KuberContext, O::Symbol, d::Dict{String,Any})
     isempty(ctx.apis) && set_api_versions!(ctx)
 
-    if haskey(d, "apiVersion")
-        v = d["apiVersion"]
-        k = Kuber.api_group_type(v)
-        apictx = k(ctx.client)
-    else
-        kapi = ctx.modelapi[O]
-        apictx = kapi.api(ctx.client)
-    end
-
+    apictx = _get_apictx(ctx, O, haskey(d, "apiVersion") ? d["apiVersion"] : nothing)
     try
         apicall = eval(Symbol("create$O"))
         return apicall(apictx, d)
@@ -124,23 +112,12 @@ function delete!(ctx::KuberContext, v::T; kwargs...) where {T<:SwaggerModel}
     vjson = convert(Dict{String,Any}, v)
     kind = vjson["kind"]
     name = vjson["metadata"]["name"]
-    delete!(ctx, Symbol(kind), name; kwargs...)
+    delete!(ctx, Symbol(kind), name, (haskey(vjson, "apiVersion") ? vjson["apiVersion"] : nothing); kwargs...)
 end
 
-function delete!(ctx::KuberContext, O::Symbol, name::String; kwargs...)
+function delete!(ctx::KuberContext, O::Symbol, name::String, apiversion::Union{String,Nothing}=nothing; kwargs...)
     isempty(ctx.apis) && set_api_versions!(ctx)
-    d = Dict(kwargs)
-
-    if haskey(d, :apiVersion)
-        v = d[:apiVersion]
-        k = Kuber.api_group_type(v)
-        apictx = k(ctx.client)
-        delete!(d, :apiVersion)
-        kwargs = d
-    else
-        kapi = ctx.modelapi[O]
-        apictx = kapi.api(ctx.client)
-    end
+    apictx = _get_apictx(ctx, O, apiversion)
 
     params = [apictx, name]
 
@@ -159,14 +136,13 @@ function update!(ctx::KuberContext, v::T, patch, patch_type) where {T<:SwaggerMo
     vjson = convert(Dict{String,Any}, v)
     kind = vjson["kind"]
     name = vjson["metadata"]["name"]
-    update!(ctx, Symbol(kind), name, patch, patch_type)
+    update!(ctx, Symbol(kind), name, patch, patch_type, (haskey(vjson, "apiVersion") ? vjson["apiVersion"] : nothing))
 end
 
-function update!(ctx::KuberContext, O::Symbol, name::String, patch, patch_type)
+function update!(ctx::KuberContext, O::Symbol, name::String, patch, patch_type, apiversion::Union{String,Nothing}=nothing)
     isempty(ctx.apis) && set_api_versions!(ctx)
 
-    kapi = ctx.modelapi[O]
-    apictx = kapi.api(ctx.client)
+    apictx = _get_apictx(ctx, O, apiversion)
 
     try
         apicall = eval(Symbol("patch$O"))

--- a/src/simpleapi.jl
+++ b/src/simpleapi.jl
@@ -51,9 +51,18 @@ end
 
 function get(ctx::KuberContext, O::Symbol, name::String; kwargs...)
     isempty(ctx.apis) && set_api_versions!(ctx)
+    d = Dict(kwargs)
 
-    kapi = ctx.modelapi[O]
-    apictx = kapi.api(ctx.client)
+    if haskey(d, :apiVersion)
+        v = d[:apiVersion]
+        k = Kuber.api_group_type(v)
+        apictx = k(ctx.client)
+	delete!(d, :apiVersion)
+	kwargs = d
+    else
+        kapi = ctx.modelapi[O]
+        apictx = kapi.api(ctx.client)
+    end
 
     try
         apicall = eval(Symbol("read$O"))
@@ -120,9 +129,19 @@ end
 
 function delete!(ctx::KuberContext, O::Symbol, name::String; kwargs...)
     isempty(ctx.apis) && set_api_versions!(ctx)
+    d = Dict(kwargs)
 
-    kapi = ctx.modelapi[O]
-    apictx = kapi.api(ctx.client)
+    if haskey(d, :apiVersion)
+        v = d[:apiVersion]
+        k = Kuber.api_group_type(v)
+        apictx = k(ctx.client)
+	delete!(d, :apiVersion)
+	kwargs = d
+    else
+        kapi = ctx.modelapi[O]
+        apictx = kapi.api(ctx.client)
+    end
+
     params = [apictx, name]
 
     try

--- a/src/simpleapi.jl
+++ b/src/simpleapi.jl
@@ -57,8 +57,8 @@ function get(ctx::KuberContext, O::Symbol, name::String; kwargs...)
         v = d[:apiVersion]
         k = Kuber.api_group_type(v)
         apictx = k(ctx.client)
-	delete!(d, :apiVersion)
-	kwargs = d
+        delete!(d, :apiVersion)
+        kwargs = d
     else
         kapi = ctx.modelapi[O]
         apictx = kapi.api(ctx.client)
@@ -135,8 +135,8 @@ function delete!(ctx::KuberContext, O::Symbol, name::String; kwargs...)
         v = d[:apiVersion]
         k = Kuber.api_group_type(v)
         apictx = k(ctx.client)
-	delete!(d, :apiVersion)
-	kwargs = d
+        delete!(d, :apiVersion)
+        kwargs = d
     else
         kapi = ctx.modelapi[O]
         apictx = kapi.api(ctx.client)

--- a/src/simpleapi.jl
+++ b/src/simpleapi.jl
@@ -10,7 +10,7 @@ sel(cnd::String...) = join(cnd, ", ")
 _delopts(; kwargs...) = Typedefs.MetaV1.DeleteOptions(; preconditions=Typedefs.MetaV1.Preconditions(; kwargs...), kwargs...)
 
 function _get_apictx(ctx::KuberContext, O::Symbol, apiversion::Union{String,Nothing})
-    if apiversion != nothing
+    if apiversion !== nothing
         k = Kuber.api_group_type(apiversion)
         apictx = k(ctx.client)
     else
@@ -97,7 +97,7 @@ end
 function put!(ctx::KuberContext, O::Symbol, d::Dict{String,Any})
     isempty(ctx.apis) && set_api_versions!(ctx)
 
-    apictx = _get_apictx(ctx, O, haskey(d, "apiVersion") ? d["apiVersion"] : nothing)
+    apictx = _get_apictx(ctx, O, get(d, "apiVersion", nothing))
     try
         apicall = eval(Symbol("create$O"))
         return apicall(apictx, d)
@@ -112,7 +112,7 @@ function delete!(ctx::KuberContext, v::T; kwargs...) where {T<:SwaggerModel}
     vjson = convert(Dict{String,Any}, v)
     kind = vjson["kind"]
     name = vjson["metadata"]["name"]
-    delete!(ctx, Symbol(kind), name, (haskey(vjson, "apiVersion") ? vjson["apiVersion"] : nothing); kwargs...)
+    delete!(ctx, Symbol(kind), name, get(vjson, "apiVersion", nothing); kwargs...)
 end
 
 function delete!(ctx::KuberContext, O::Symbol, name::String, apiversion::Union{String,Nothing}=nothing; kwargs...)
@@ -136,7 +136,7 @@ function update!(ctx::KuberContext, v::T, patch, patch_type) where {T<:SwaggerMo
     vjson = convert(Dict{String,Any}, v)
     kind = vjson["kind"]
     name = vjson["metadata"]["name"]
-    update!(ctx, Symbol(kind), name, patch, patch_type, (haskey(vjson, "apiVersion") ? vjson["apiVersion"] : nothing))
+    update!(ctx, Symbol(kind), name, patch, patch_type, get(vjson, "apiVersion", nothing))
 end
 
 function update!(ctx::KuberContext, O::Symbol, name::String, patch, patch_type, apiversion::Union{String,Nothing}=nothing)


### PR DESCRIPTION
Provides the ability to specify `apiVersion` in `get` and `delete!`. Helps in cases like `:CronJob` types where the APIs are still in beta.