### PR TITLE
Added retry capability for get APIs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Swagger = "2d69052b-6a58-5cd9-a030-a48559c324ac"
+Retry = "20febd7b-183b-5ae2-ac4a-720e7ce64774"
 
 [compat]
 HTTP = "0.8"

--- a/src/Kuber.jl
+++ b/src/Kuber.jl
@@ -3,6 +3,7 @@ module Kuber
 using JSON
 using Swagger
 using HTTP
+using Retry, HTTP.IOExtras
 
 include("api/Kubernetes.jl")
 using .Kubernetes

--- a/src/simpleapi.jl
+++ b/src/simpleapi.jl
@@ -58,13 +58,13 @@ function list(ctx::KuberContext, O::Symbol, apiversion::Union{String,Nothing}=no
     end
 end
 
-function get(ctx::KuberContext, O::Symbol, name::String, apiversion::Union{String,Nothing}=nothing; num_tries::Integer=1, kwargs...)
-    isempty(ctx.apis) && set_api_versions!(ctx; num_tries=num_tries)
+function get(ctx::KuberContext, O::Symbol, name::String, apiversion::Union{String,Nothing}=nothing; max_tries::Integer=1, kwargs...)
+    isempty(ctx.apis) && set_api_versions!(ctx; max_tries=max_tries)
 
     apictx = _get_apictx(ctx, O, apiversion)
     try
         apicall = eval(Symbol("read$O"))
-        @repeat num_tries try
+        @repeat max_tries try
             return apicall(apictx, name; kwargs...)
         catch e
             @retry if isa(e, IOError)
@@ -75,7 +75,7 @@ function get(ctx::KuberContext, O::Symbol, name::String, apiversion::Union{Strin
     catch ex
         isa(ex, UndefVarError) || rethrow()
         apicall = eval(Symbol("readNamespaced$O"))
-        @repeat num_tries try
+        @repeat max_tries try
             return apicall(apictx, name, ctx.namespace; kwargs...)
         catch e
             @retry if isa(e, IOError)
@@ -86,15 +86,15 @@ function get(ctx::KuberContext, O::Symbol, name::String, apiversion::Union{Strin
     end
 end
 
-function get(ctx::KuberContext, O::Symbol, apiversion::Union{String,Nothing}=nothing; label_selector=nothing, namespace::Union{String,Nothing}=ctx.namespace, num_tries::Integer=1)
-    isempty(ctx.apis) && set_api_versions!(ctx; num_tries=num_tries)
+function get(ctx::KuberContext, O::Symbol, apiversion::Union{String,Nothing}=nothing; label_selector=nothing, namespace::Union{String,Nothing}=ctx.namespace, max_tries::Integer=1)
+    isempty(ctx.apis) && set_api_versions!(ctx; max_tries=max_tries)
 
     apictx = _get_apictx(ctx, O, apiversion)
     try
         apiname = "list$O"
         (namespace === nothing) && (apiname *= "ForAllNamespaces")
         apicall = eval(Symbol(apiname))
-        @repeat num_tries try
+        @repeat max_tries try
             return apicall(apictx; labelSelector=label_selector)
         catch e
             @retry if isa(e, IOError)
@@ -106,7 +106,7 @@ function get(ctx::KuberContext, O::Symbol, apiversion::Union{String,Nothing}=not
         isa(ex, UndefVarError) || rethrow()
         (namespace === nothing) && rethrow()
         apicall = eval(Symbol("listNamespaced$O"))
-        @repeat num_tries try
+        @repeat max_tries try
             return apicall(apictx, namespace; labelSelector=label_selector)
         catch e
             @retry if isa(e, IOError)

--- a/src/simpleapi.jl
+++ b/src/simpleapi.jl
@@ -1,4 +1,4 @@
-using Retry
+using Retry, HTTP.IOExtras
 
 # simple Julia APIs over Kubernetes Swagger interface
 

--- a/src/simpleapi.jl
+++ b/src/simpleapi.jl
@@ -1,5 +1,3 @@
-using Retry, HTTP.IOExtras
-
 # simple Julia APIs over Kubernetes Swagger interface
 
 function sel(label::String, op::Symbol)

--- a/src/simpleapi.jl
+++ b/src/simpleapi.jl
@@ -59,7 +59,7 @@ function list(ctx::KuberContext, O::Symbol, apiversion::Union{String,Nothing}=no
 end
 
 function get(ctx::KuberContext, O::Symbol, name::String, apiversion::Union{String,Nothing}=nothing; num_tries::Integer=1, kwargs...)
-    isempty(ctx.apis) && set_api_versions!(ctx)
+    isempty(ctx.apis) && set_api_versions!(ctx; num_tries=num_tries)
 
     apictx = _get_apictx(ctx, O, apiversion)
     try
@@ -68,7 +68,7 @@ function get(ctx::KuberContext, O::Symbol, name::String, apiversion::Union{Strin
             return apicall(apictx, name; kwargs...)
         catch e
             @retry if isa(e, IOError)
-                @warn("Retrying ", "read$O")
+                @debug("Retrying ", "read$O")
                 sleep(2)
             end
         end
@@ -79,7 +79,7 @@ function get(ctx::KuberContext, O::Symbol, name::String, apiversion::Union{Strin
             return apicall(apictx, name, ctx.namespace; kwargs...)
         catch e
             @retry if isa(e, IOError)
-                @warn("Retrying ", "readNamespaced$O")
+                @debug("Retrying ", "readNamespaced$O")
                 sleep(2)
             end
         end
@@ -87,7 +87,7 @@ function get(ctx::KuberContext, O::Symbol, name::String, apiversion::Union{Strin
 end
 
 function get(ctx::KuberContext, O::Symbol, apiversion::Union{String,Nothing}=nothing; label_selector=nothing, namespace::Union{String,Nothing}=ctx.namespace, num_tries::Integer=1)
-    isempty(ctx.apis) && set_api_versions!(ctx)
+    isempty(ctx.apis) && set_api_versions!(ctx; num_tries=num_tries)
 
     apictx = _get_apictx(ctx, O, apiversion)
     try
@@ -98,7 +98,7 @@ function get(ctx::KuberContext, O::Symbol, apiversion::Union{String,Nothing}=not
             return apicall(apictx; labelSelector=label_selector)
         catch e
             @retry if isa(e, IOError)
-                @warn("Retrying ", apiname)
+                @debug("Retrying ", apiname)
                 sleep(2)
             end
         end
@@ -110,7 +110,7 @@ function get(ctx::KuberContext, O::Symbol, apiversion::Union{String,Nothing}=not
             return apicall(apictx, namespace; labelSelector=label_selector)
         catch e
             @retry if isa(e, IOError)
-                @warn("Retrying ", "listNamespaced$O")
+                @debug("Retrying ", "listNamespaced$O")
                 sleep(2)
             end
         end

--- a/src/simpleapi.jl
+++ b/src/simpleapi.jl
@@ -86,6 +86,7 @@ function get(ctx::KuberContext, O::Symbol, apiversion::Union{String,Nothing}=not
             return apicall(apictx; labelSelector=label_selector)
         catch e
             @retry if isa(e, IOError)
+                @warn("Retrying ", apiname)
                 sleep(3)
             end
         end


### PR DESCRIPTION
At this point of time retry is added only for `get` APIs. In future, it will be good to add to other APIs as well.