### PR TITLE
correctly detect uninitialized context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,7 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.1
-  - 1.2
-  - 1.3
-  - 1.4
+  - 1
   - nightly
 matrix:
   allow_failures:

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -11,11 +11,12 @@ mutable struct KuberContext
     apis::Dict{Symbol,Vector{KApi}}
     modelapi::Dict{Symbol,KApi}
     namespace::String
+    initialized::Bool
 
     function KuberContext()
         ctx = Swagger.Client(DEFAULT_URI)
         ctx.headers["Connection"] = "close"
-        new(ctx, Dict{Symbol,Vector}(), Dict{Symbol,KApi}(), DEFAULT_NAMESPACE)
+        new(ctx, Dict{Symbol,Vector}(), Dict{Symbol,KApi}(), DEFAULT_NAMESPACE, false)
     end
 end
 
@@ -211,6 +212,7 @@ function build_model_api_map(ctx::KuberContext)
 end
 
 function set_api_versions!(ctx::KuberContext; override=nothing, verbose::Bool=false, max_tries=1)
+    ctx.initialized = false
     empty!(ctx.apis)
     empty!(ctx.modelapi)
 
@@ -225,5 +227,6 @@ function set_api_versions!(ctx::KuberContext; override=nothing, verbose::Bool=fa
 
     # add custom models
     ctx.modelapi[:PodLog] = ctx.modelapi[:Pod]
+    ctx.initialized = true
     nothing
 end

--- a/src/simpleapi.jl
+++ b/src/simpleapi.jl
@@ -24,7 +24,7 @@ _api_function(name::Symbol) = isdefined(@__MODULE__, name) ? eval(name) : nothin
 _api_function(name) = _api_function(Symbol(name))
 
 function list(ctx::KuberContext, O::Symbol, name::String; apiversion::Union{String,Nothing}=nothing, namespace::Union{String,Nothing}=ctx.namespace, kwargs...)
-    isempty(ctx.apis) && set_api_versions!(ctx)
+    ctx.initialized || set_api_versions!(ctx)
 
     apictx = _get_apictx(ctx, O, apiversion)
     namespaced = (namespace !== nothing) && !isempty(namespace)
@@ -43,7 +43,7 @@ function list(ctx::KuberContext, O::Symbol, name::String; apiversion::Union{Stri
 end
 
 function list(ctx::KuberContext, O::Symbol; apiversion::Union{String,Nothing}=nothing, namespace::Union{String,Nothing}=ctx.namespace, kwargs...)
-    isempty(ctx.apis) && set_api_versions!(ctx)
+    ctx.initialized || set_api_versions!(ctx)
 
     apictx = _get_apictx(ctx, O, apiversion)
     namespaced = (namespace !== nothing) && !isempty(namespace)
@@ -62,7 +62,7 @@ function list(ctx::KuberContext, O::Symbol; apiversion::Union{String,Nothing}=no
 end
 
 function get(ctx::KuberContext, O::Symbol, name::String; apiversion::Union{String,Nothing}=nothing, max_tries::Integer=1, kwargs...)
-    isempty(ctx.apis) && set_api_versions!(ctx; max_tries=max_tries)
+    ctx.initialized || set_api_versions!(ctx; max_tries=max_tries)
 
     apictx = _get_apictx(ctx, O, apiversion)
     if (apicall = _api_function("read$O")) !== nothing
@@ -89,7 +89,7 @@ function get(ctx::KuberContext, O::Symbol, name::String; apiversion::Union{Strin
 end
 
 function get(ctx::KuberContext, O::Symbol; apiversion::Union{String,Nothing}=nothing, label_selector=nothing, namespace::Union{String,Nothing}=ctx.namespace, max_tries::Integer=1)
-    isempty(ctx.apis) && set_api_versions!(ctx; max_tries=max_tries)
+    ctx.initialized || set_api_versions!(ctx; max_tries=max_tries)
 
     apictx = _get_apictx(ctx, O, apiversion)
     apiname = "list$O"
@@ -123,7 +123,7 @@ function put!(ctx::KuberContext, v::T) where {T<:SwaggerModel}
 end
 
 function put!(ctx::KuberContext, O::Symbol, d::Dict{String,Any})
-    isempty(ctx.apis) && set_api_versions!(ctx)
+    ctx.initialized || set_api_versions!(ctx)
 
     apictx = _get_apictx(ctx, O, get(d, "apiVersion", nothing))
     if (apicall = _api_function("create$O")) !== nothing
@@ -143,7 +143,7 @@ function delete!(ctx::KuberContext, v::T; kwargs...) where {T<:SwaggerModel}
 end
 
 function delete!(ctx::KuberContext, O::Symbol, name::String; apiversion::Union{String,Nothing}=nothing, kwargs...)
-    isempty(ctx.apis) && set_api_versions!(ctx)
+    ctx.initialized || set_api_versions!(ctx)
     apictx = _get_apictx(ctx, O, apiversion)
 
     params = [apictx, name]
@@ -166,7 +166,7 @@ function update!(ctx::KuberContext, v::T, patch, patch_type) where {T<:SwaggerMo
 end
 
 function update!(ctx::KuberContext, O::Symbol, name::String, patch, patch_type; apiversion::Union{String,Nothing}=nothing)
-    isempty(ctx.apis) && set_api_versions!(ctx)
+    ctx.initialized || set_api_versions!(ctx)
 
     apictx = _get_apictx(ctx, O, apiversion)
 


### PR DESCRIPTION
There are multiple steps involved while initializing a context. The initialization status should be stored in an explicit flag instead of checking certain fields of the context. This changes the `set_api_versions!` (which is what is used to initialize the context) to set a new flag in the context. All other methods check the flag and call `set_api_versions!` if the context is not initialized.

fixes: #27