### PR TITLE
Refactor retry logic with macro, add this retry macro to list API

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -250,7 +250,7 @@ Macro to retry an expression on `IOError`. Note that the variable `max_tries` ne
 """
 macro retry_on_error(e)
    esc(quote
-      retry_on_error(;max_tries=max_tries) do
+      retry_on_error(;max_tries=(@isdefined max_tries) ? max_tries : 1) do
           $(e)
       end
    end)

--- a/src/simpleapi.jl
+++ b/src/simpleapi.jl
@@ -94,14 +94,14 @@ function put!(ctx::KuberContext, v::T) where {T<:SwaggerModel}
     put!(ctx, Symbol(vjson["kind"]), vjson)
 end
 
-function put!(ctx::KuberContext, O::Symbol, d::Dict{String,Any}; max_tries::Int=1)
+function put!(ctx::KuberContext, O::Symbol, d::Dict{String,Any})
     ctx.initialized || set_api_versions!(ctx)
 
     apictx = _get_apictx(ctx, O, get(d, "apiVersion", nothing))
     if (apicall = _api_function("create$O")) !== nothing
-        return @retry_on_error apicall(apictx, d)
+        return apicall(apictx, d)
     elseif (apicall = _api_function("createNamespaced$O")) !== nothing
-        return @retry_on_error apicall(apictx, ctx.namespace, d)
+        return apicall(apictx, ctx.namespace, d)
     else
         throw(ArgumentError("No API functions could be located using :$O"))
     end
@@ -114,17 +114,17 @@ function delete!(ctx::KuberContext, v::T; kwargs...) where {T<:SwaggerModel}
     delete!(ctx, Symbol(kind), name; apiversion=get(vjson, "apiVersion", nothing), kwargs...)
 end
 
-function delete!(ctx::KuberContext, O::Symbol, name::String; apiversion::Union{String,Nothing}=nothing, max_tries::Int=1, kwargs...)
+function delete!(ctx::KuberContext, O::Symbol, name::String; apiversion::Union{String,Nothing}=nothing, kwargs...)
     ctx.initialized || set_api_versions!(ctx)
     apictx = _get_apictx(ctx, O, apiversion)
 
     params = [apictx, name]
 
     if (apicall = _api_function("delete$O")) !== nothing
-        return @retry_on_error apicall(params...; kwargs...)
+        return apicall(params...; kwargs...)
     elseif (apicall = _api_function("deleteNamespaced$O")) !== nothing
         push!(params, ctx.namespace)
-        return @retry_on_error apicall(params...; kwargs...)
+        return apicall(params...; kwargs...)
     else
         throw(ArgumentError("No API functions could be located using :$O"))
     end
@@ -137,15 +137,15 @@ function update!(ctx::KuberContext, v::T, patch, patch_type) where {T<:SwaggerMo
     update!(ctx, Symbol(kind), name, patch, patch_type; apiversion=get(vjson, "apiVersion", nothing))
 end
 
-function update!(ctx::KuberContext, O::Symbol, name::String, patch, patch_type; apiversion::Union{String,Nothing}=nothing, max_tries::Int=1)
+function update!(ctx::KuberContext, O::Symbol, name::String, patch, patch_type; apiversion::Union{String,Nothing}=nothing)
     ctx.initialized || set_api_versions!(ctx)
 
     apictx = _get_apictx(ctx, O, apiversion)
 
     if (apicall = _api_function("patch$O")) !== nothing
-        return @retry_on_error apicall(apictx, name, patch; _mediaType=patch_type)
+        return apicall(apictx, name, patch; _mediaType=patch_type)
     elseif (apicall = _api_function("patchNamespaced$O")) !== nothing
-        return @retry_on_error apicall(apictx, name, ctx.namespace, patch; _mediaType=patch_type)
+        return apicall(apictx, name, ctx.namespace, patch; _mediaType=patch_type)
     else
         throw(ArgumentError("No API functions could be located using :$O"))
     end

--- a/src/simpleapi.jl
+++ b/src/simpleapi.jl
@@ -94,7 +94,7 @@ function put!(ctx::KuberContext, v::T) where {T<:SwaggerModel}
     put!(ctx, Symbol(vjson["kind"]), vjson)
 end
 
-function put!(ctx::KuberContext, O::Symbol, d::Dict{String,Any})
+function put!(ctx::KuberContext, O::Symbol, d::Dict{String,Any}; max_tries::Int=1)
     ctx.initialized || set_api_versions!(ctx)
 
     apictx = _get_apictx(ctx, O, get(d, "apiVersion", nothing))
@@ -114,7 +114,7 @@ function delete!(ctx::KuberContext, v::T; kwargs...) where {T<:SwaggerModel}
     delete!(ctx, Symbol(kind), name; apiversion=get(vjson, "apiVersion", nothing), kwargs...)
 end
 
-function delete!(ctx::KuberContext, O::Symbol, name::String; apiversion::Union{String,Nothing}=nothing, kwargs...)
+function delete!(ctx::KuberContext, O::Symbol, name::String; apiversion::Union{String,Nothing}=nothing, max_tries::Int=1, kwargs...)
     ctx.initialized || set_api_versions!(ctx)
     apictx = _get_apictx(ctx, O, apiversion)
 
@@ -137,7 +137,7 @@ function update!(ctx::KuberContext, v::T, patch, patch_type) where {T<:SwaggerMo
     update!(ctx, Symbol(kind), name, patch, patch_type; apiversion=get(vjson, "apiVersion", nothing))
 end
 
-function update!(ctx::KuberContext, O::Symbol, name::String, patch, patch_type; apiversion::Union{String,Nothing}=nothing)
+function update!(ctx::KuberContext, O::Symbol, name::String, patch, patch_type; apiversion::Union{String,Nothing}=nothing, max_tries::Int=1)
     ctx.initialized || set_api_versions!(ctx)
 
     apictx = _get_apictx(ctx, O, apiversion)

--- a/src/simpleapi.jl
+++ b/src/simpleapi.jl
@@ -23,7 +23,7 @@ end
 _api_function(name::Symbol) = isdefined(@__MODULE__, name) ? eval(name) : nothing
 _api_function(name) = _api_function(Symbol(name))
 
-function list(ctx::KuberContext, O::Symbol, name::String; apiversion::Union{String,Nothing}=nothing, namespace::Union{String,Nothing}=ctx.namespace, kwargs...)
+function list(ctx::KuberContext, O::Symbol, name::String; apiversion::Union{String,Nothing}=nothing, namespace::Union{String,Nothing}=ctx.namespace, max_tries::Int=1, kwargs...)
     ctx.initialized || set_api_versions!(ctx)
 
     apictx = _get_apictx(ctx, O, apiversion)
@@ -32,17 +32,17 @@ function list(ctx::KuberContext, O::Symbol, name::String; apiversion::Union{Stri
 
     if allnamespaces
         apicall = eval(Symbol("list$(O)ForAllNamespaces"))
-        return apicall(apictx, name; kwargs...)
+        return @retry_on_error apicall(apictx, name; kwargs...)
     elseif namespaced
         apicall = eval(Symbol("listNamespaced$O"))
-        return apicall(apictx, name, namespace; kwargs...)
+        return @retry_on_error apicall(apictx, name, namespace; kwargs...)
     else
         apicall = eval(Symbol("list$O"))
-        return apicall(apictx, name; kwargs...)
+        return @retry_on_error apicall(apictx, name; kwargs...)
     end
 end
 
-function list(ctx::KuberContext, O::Symbol; apiversion::Union{String,Nothing}=nothing, namespace::Union{String,Nothing}=ctx.namespace, kwargs...)
+function list(ctx::KuberContext, O::Symbol; apiversion::Union{String,Nothing}=nothing, namespace::Union{String,Nothing}=ctx.namespace, max_tries::Int=1, kwargs...)
     ctx.initialized || set_api_versions!(ctx)
 
     apictx = _get_apictx(ctx, O, apiversion)
@@ -51,13 +51,13 @@ function list(ctx::KuberContext, O::Symbol; apiversion::Union{String,Nothing}=no
 
     if allnamespaces
         apicall = eval(Symbol("list$(O)ForAllNamespaces"))
-        return apicall(apictx; kwargs...)
+        return @retry_on_error apicall(apictx; kwargs...)
     elseif namespaced
         apicall = eval(Symbol("listNamespaced$O"))
-        return apicall(apictx, namespace; kwargs...)
+        return @retry_on_error apicall(apictx, namespace; kwargs...)
     else
         apicall = eval(Symbol("list$O"))
-        return apicall(apictx; kwargs...)
+        return @retry_on_error apicall(apictx; kwargs...)
     end
 end
 
@@ -66,23 +66,9 @@ function get(ctx::KuberContext, O::Symbol, name::String; apiversion::Union{Strin
 
     apictx = _get_apictx(ctx, O, apiversion)
     if (apicall = _api_function("read$O")) !== nothing
-        @repeat max_tries try
-            return apicall(apictx, name; kwargs...)
-        catch e
-            @retry if isa(e, IOError)
-                @debug("Retrying ", nameof(apicall))
-                sleep(2)
-            end
-        end
+        return @retry_on_error apicall(apictx, name; kwargs...)
     elseif (apicall = _api_function("readNamespaced$O")) !== nothing
-        @repeat max_tries try
-            return apicall(apictx, name, ctx.namespace; kwargs...)
-        catch e
-            @retry if isa(e, IOError)
-                @debug("Retrying ", nameof(apicall))
-                sleep(2)
-            end
-        end
+        return @retry_on_error apicall(apictx, name, ctx.namespace; kwargs...)
     else
         throw(ArgumentError("No API functions could be located using :$O"))
     end
@@ -95,23 +81,9 @@ function get(ctx::KuberContext, O::Symbol; apiversion::Union{String,Nothing}=not
     apiname = "list$O"
     namespace === nothing && (apiname *= "ForAllNamespaces")
     if (apicall = _api_function(apiname)) !== nothing
-        @repeat max_tries try
-            return apicall(apictx; labelSelector=label_selector)
-        catch e
-            @retry if isa(e, IOError)
-                @debug("Retrying ", nameof(apicall))
-                sleep(2)
-            end
-        end
+        return @retry_on_error apicall(apictx; labelSelector=label_selector)
     elseif (apicall = _api_function("listNamespaced$O")) !== nothing
-        @repeat max_tries try
-            return apicall(apictx, namespace; labelSelector=label_selector)
-        catch e
-            @retry if isa(e, IOError)
-                @debug("Retrying ", nameof(apicall))
-                sleep(2)
-            end
-        end
+        return @retry_on_error apicall(apictx, namespace; labelSelector=label_selector)
     else
         throw(ArgumentError("No API functions could be located using :$O"))
     end
@@ -127,9 +99,9 @@ function put!(ctx::KuberContext, O::Symbol, d::Dict{String,Any})
 
     apictx = _get_apictx(ctx, O, get(d, "apiVersion", nothing))
     if (apicall = _api_function("create$O")) !== nothing
-        return apicall(apictx, d)
+        return @retry_on_error apicall(apictx, d)
     elseif (apicall = _api_function("createNamespaced$O")) !== nothing
-        return apicall(apictx, ctx.namespace, d)
+        return @retry_on_error apicall(apictx, ctx.namespace, d)
     else
         throw(ArgumentError("No API functions could be located using :$O"))
     end
@@ -149,10 +121,10 @@ function delete!(ctx::KuberContext, O::Symbol, name::String; apiversion::Union{S
     params = [apictx, name]
 
     if (apicall = _api_function("delete$O")) !== nothing
-        return apicall(params...; kwargs...)
+        return @retry_on_error apicall(params...; kwargs...)
     elseif (apicall = _api_function("deleteNamespaced$O")) !== nothing
         push!(params, ctx.namespace)
-        return apicall(params...; kwargs...)
+        return @retry_on_error apicall(params...; kwargs...)
     else
         throw(ArgumentError("No API functions could be located using :$O"))
     end
@@ -171,9 +143,9 @@ function update!(ctx::KuberContext, O::Symbol, name::String, patch, patch_type; 
     apictx = _get_apictx(ctx, O, apiversion)
 
     if (apicall = _api_function("patch$O")) !== nothing
-        return apicall(apictx, name, patch; _mediaType=patch_type)
+        return @retry_on_error apicall(apictx, name, patch; _mediaType=patch_type)
     elseif (apicall = _api_function("patchNamespaced$O")) !== nothing
-        return apicall(apictx, name, ctx.namespace, patch; _mediaType=patch_type)
+        return @retry_on_error apicall(apictx, name, ctx.namespace, patch; _mediaType=patch_type)
     else
         throw(ArgumentError("No API functions could be located using :$O"))
     end


### PR DESCRIPTION
Created a macro `retry_on_error` that does the `@repeat`, `try`, `catch`, `@retry` routine. This makes things a bit cleaner I think. Also added the macro to the `list` API.