### PR TITLE
enable full ci with a KinD k8s cluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,20 +19,18 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
-          - x86
-        include:
-          # test macOS and Windows with latest Julia only
-          - os: macOS-latest
-            arch: x64
-            version: 1
-          - os: windows-latest
-            arch: x64
-            version: 1
-          - os: windows-latest
-            arch: x86
-            version: 1
     steps:
       - uses: actions/checkout@v2
+      - uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: "v0.11.1"
+      - name: Testing
+        run: |
+          kubectl cluster-info
+          kubectl get pods -n kube-system
+          echo "current-context:" $(kubectl config current-context)
+          echo "environment-kubeconfig:" ${KUBECONFIG}
+          kubectl proxy &
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kuber
 
-[![Build Status](https://travis-ci.org/JuliaComputing/Kuber.jl.svg?branch=master)](https://travis-ci.org/JuliaComputing/Kuber.jl)
+[![Build Status](https://github.com/JuliaComputing/Kuber.jl/workflows/CI/badge.svg)](https://github.com/JuliaComputing/Kuber.jl/actions?query=workflow%3ACI+branch%3Amaster)
 
 A Julia Kubernetes Client.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -276,13 +276,13 @@ function test_versioned(ctx, testid)
     @testset "Watch Events" begin
         timedwait(10.0; pollint=1.0) do
             lock(lck) do
-                any(isa(event, Kuber.Kubernetes.IoK8sApimachineryPkgApisMetaV1WatchEvent) && (event.type == "DELETED") for event in events)
+                any(isa(event, Kuber.Typedefs.MetaV1.WatchEvent) && (event.type == "DELETED") for event in events)
             end
         end
         lock(lck) do
             @test !isempty(events)
             for event in events
-                @test isa(event, Union{Kuber.Kubernetes.IoK8sApimachineryPkgApisMetaV1WatchEvent,Kuber.Kubernetes.IoK8sApiCoreV1PodList})
+                @test isa(event, Union{Kuber.Typedefs.MetaV1.WatchEvent,Kuber.Typedefs.CoreV1.PodList})
             end
         end
     end
@@ -308,6 +308,6 @@ function test_all()
     end
 end
 
-if !parse(Bool, get(ENV, "CI", "false"))
+#if !parse(Bool, get(ENV, "CI", "false"))
     test_all()
-end
+#end


### PR DESCRIPTION
Use KinD (Kubernetes in Docker) GitHub Action to enable full tests for the package.