### PR TITLE
also allow retries of mutating APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A Kubernetes context can be manipulated with:
 
 - `set_server`: Set the API server location ("http://localhost:8001" if not set)
 - `set_ns`: Set the namespace to deal with (`default` namespace is not set)
-- `set_retries`: Set the number of times an API call should be retried on a retriable error (5 if not set)
+- `set_retries`: Set the number of times an API call should be retried on a retriable error (5 if not set) and whether all APIs should be retried (only non mutating APIs are retried by default)
 
 Other convenience methods:
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ function init_context(override=nothing, verbose=true)
     ctx = KuberContext()
     set_server(ctx, "http://localhost:8001")
     set_ns(ctx, "default")
-    set_retries(ctx, 3)
+    set_retries(ctx; count=3, all_apis=false)
     Kuber.set_api_versions!(ctx; override=override, verbose=verbose)
     ctx
 end


### PR DESCRIPTION
State changing APIs are not retried by default. But added an optional keyword arg to switch that on when the caller desires.
Should be safe when retried only on 50x server errors or connect errors.