### PR TITLE
allow timeout to be set via KuberContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Julia Kubernetes Client.
 
-An easy to use API to access Kubernetes clusters from Julia. The `Kuber.Kubernetes` submodule has the complete set of low level APIs and entities.
+An easy to use API to access Kubernetes clusters from Julia. The `Kuber.ApiImpl.Kubernetes` submodule has the complete set of low level APIs and entities.
 
 Most of the low level APIs fit into a common usage pattern. Kuber.jl makes it possible to use all of them with only a few intuitive verb based APIs. Verbs act on entities. Entities can be identified by names or selector patterns, or otherwise can apply to all entities of that class. Verbs can take additional parameters, e.g. when creating or updating entities.
 

--- a/WalkThrough.md
+++ b/WalkThrough.md
@@ -145,10 +145,10 @@ Now that we have set up our connection properly, let's explore what we have in o
 julia> result = get(ctx, :ComponentStatus);
 
 julia> typeof(result)
-Kuber.Kubernetes.IoK8sApiCoreV1ComponentStatusList
+Kuber.ApiImpl.Kubernetes.IoK8sApiCoreV1ComponentStatusList
 ```
 
-Note that we got back a Julia type `Kuber.Kubernetes.IoK8sApiCoreV1ComponentStatusList`. It represents a list of `ComponentStatus` entities that we asked for. It has been resolved to match the specific to the version of API we used - `CoreV1` in this case. We can display the entity in JSON form in the REPL, by simply `show`ing it.
+Note that we got back a Julia type `Kuber.ApiImpl.Kubernetes.IoK8sApiCoreV1ComponentStatusList`. It represents a list of `ComponentStatus` entities that we asked for. It has been resolved to match the specific to the version of API we used - `CoreV1` in this case. We can display the entity in JSON form in the REPL, by simply `show`ing it.
 
 ```julia
 julia> result
@@ -245,7 +245,7 @@ julia> nginx_pod = kuber_obj(ctx, """{
        }""");
 
 julia> typeof(nginx_pod)
-Kuber.Kubernetes.IoK8sApiCoreV1Pod
+Kuber.ApiImpl.Kubernetes.IoK8sApiCoreV1Pod
 
 julia> nginx_service = kuber_obj(ctx, """{
            "kind": "Service",
@@ -263,7 +263,7 @@ julia> nginx_service = kuber_obj(ctx, """{
        }""")
 
 julia> typeof(nginx_service)
-Kuber.Kubernetes.IoK8sApiCoreV1Service
+Kuber.ApiImpl.Kubernetes.IoK8sApiCoreV1Service
 ```
 
 To create the pod in the cluster, use the `put!` API. And we should see it when we list the pods.


### PR DESCRIPTION
This allows timeout values to be specified while constructing the KuberContext instance, or modified later through a `set_timeout` API.
Also provided is a `with_timeout` API to set a timeout only within a specific scope. E.g.:

```julia
ctx = Kuber.KuberContext(; timeout=60, long_polling_timeout=600)

Kuber.set_timeout(ctx, 120)

Kuber.with_timeout(ctx, 300) do ctx
    # use ctx...
end
```