### PR TITLE
fix show method for KuberContext

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -151,7 +151,7 @@ end
 kuber_obj(ctx::KuberContext, data::String) = kuber_obj(ctx, JSON.parse(data))
 kuber_obj(ctx::KuberContext, j::Dict{String,Any}) = convert(kind_to_type(ctx, j["kind"], get(j, "apiVersion", nothing)), j)
 
-show(io::IO, ctx::KuberContext) = print("Kubernetes namespace ", ctx.namespace, " at ", ctx.client.root)
+show(io::IO, ctx::KuberContext) = print(io, "Kubernetes namespace ", ctx.namespace, " at ", ctx.client.root)
 
 get_server(ctx::KuberContext) = ctx.client.root
 get_ns(ctx::KuberContext) = ctx.namespace

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -331,6 +331,13 @@ function test_all()
 
             test_versioned(ctx2, "2")
         end
+
+        @testset "Misc" begin
+            iob = IOBuffer()
+            show(iob, ctx)
+            str = String(take!(iob))
+            @test str == "Kubernetes namespace default at http://localhost:8001"
+        end
     end
 end
 


### PR DESCRIPTION
fix bug in show method for KuberContext where it was not printing into the supplied `IO` instance