### PR TITLE
fix generate.sh

### DIFF
--- a/gen/generate.sh
+++ b/gen/generate.sh
@@ -51,6 +51,7 @@ rm -rf ${APIIMPLDIR}/api_bak
 mv ${APIIMPLDIR}/api ${APIIMPLDIR}/api_bak
 mkdir ${APIIMPLDIR}/api
 mv ${TEMPGENDIR}/src/* ${APIIMPLDIR}/api/
+mv ${TEMPGENDIR}/*.jl ${APIIMPLDIR}/api/
 rm ${TEMPGENDIR}/LICENSE
 rm -r ${TEMPGENDIR}
 

--- a/gen/gentypealiases.jl
+++ b/gen/gentypealiases.jl
@@ -82,6 +82,12 @@ function kuberapitypes(file::String, aliases_set::KuberTypeAliasesSet)
 end
 
 function find_matching_api(sorted_apis::Vector{String}, model_name::String)
+    if startswith(model_name, "ShKarpenter")
+        karpenter_apis = map(x->startswith(x, "KarpenterSh") ? replace(x, "KarpenterSh"=>"ShKarpenter") : x, sorted_apis)
+        api_idx = findfirst(x->startswith(model_name, x), karpenter_apis)
+        (api_idx !== nothing) && (return api_idx)
+    end
+
     rbac_apis = map(x->startswith(x, "RbacAuthorization") ? replace(x, "Authorization"=>"") : x, sorted_apis)
     flowcontrol_apis = map(x->startswith(x, "FlowcontrolApiserver") ? replace(x, "Apiserver"=>"") : x, sorted_apis)
 
@@ -95,6 +101,12 @@ function find_matching_api(sorted_apis::Vector{String}, model_name::String)
 end
 
 function get_common_name(sorted_apis::Vector{String}, model_name::String)
+    if startswith(model_name, "ShKarpenter")
+        karpenter_apis = map(x->startswith(x, "KarpenterSh") ? replace(x, "KarpenterSh"=>"ShKarpenter") : x, sorted_apis)
+        api_idx = findfirst(x->startswith(model_name, x), karpenter_apis)
+        (api_idx !== nothing) && (return replace(model_name, (karpenter_apis[api_idx])=>""))
+    end
+
     rbac_apis = map(x->startswith(x, "RbacAuthorization") ? replace(x, "Authorization"=>"") : x, sorted_apis)
     flowcontrol_apis = map(x->startswith(x, "FlowcontrolApiserver") ? replace(x, "Apiserver"=>"") : x, sorted_apis)
 


### PR DESCRIPTION
- fixed a regression in `generate.sh` where it was not transferring the generated sources correctly to the output location
- added a special case handling for karpenter crds to generate the api/model maps