### PR TITLE
better handling in `kuber_obj` method, add debug flag

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
 keywords = ["kubernetes", "client"]
 license = "MIT"
 desc = "Julia Kubernetes Client"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -206,8 +206,11 @@ function kuber_type(ctx::KuberContext, T, j::Dict{String,Any})
     T
 end
 
-kuber_obj(ctx::KuberContext, data::String) = kuber_obj(ctx, JSON.parse(data))
-kuber_obj(ctx::KuberContext, j::Dict{String,Any}) = convert(kind_to_type(ctx, j["kind"], get(j, "apiVersion", nothing)), j)
+# OpenAPI conversions insist that JSONs objects are always `Dict{String,Any}`.
+# To ensure that for a user supplied Dict, we serialize that to string and parse it back as json.
+kuber_obj(ctx::KuberContext, j::Dict{String,Any}) = kuber_obj(ctx, JSON.json(j))
+kuber_obj(ctx::KuberContext, data::String) = _kuber_obj(ctx, JSON.parse(data))
+_kuber_obj(ctx::KuberContext, j::Dict{String,Any}) = convert(kind_to_type(ctx, j["kind"], get(j, "apiVersion", nothing)), j)
 
 show(io::IO, ctx::KuberContext) = print(io, "Kubernetes namespace ", ctx.namespace, " at ", ctx.client.root)
 

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -235,10 +235,11 @@ function set_server(
     reset_api_versions::Bool=false;
     max_tries=retries(ctx, false),
     verbose::Bool=false,
+    debug::Bool=false,
     kwargs...
 )
     rtfn = (return_types,response_code,response_data)->kuber_type(ctx, return_types, response_code, response_data)
-    ctx.client = OpenAPI.Clients.Client(uri; get_return_type=rtfn, kwargs...)
+    ctx.client = OpenAPI.Clients.Client(uri; get_return_type=rtfn, verbose=debug, kwargs...)
     ctx.client.headers["Connection"] = "close"
     reset_api_versions && set_api_versions!(
         ctx;


### PR DESCRIPTION
- Add a debug flag to the Kuber context that switches on lower level HTTP debug messages through OpenAPI.jl. Useful to debug transport layer when needed.
- OpenAPI conversions insist that JSONs objects are always `Dict{String,Any}`. To ensure that for a user supplied Dict, we serialize that to string and parse it back as json.