### PR TITLE
Use the verbose on `@info` in `fetch_all_apis_versions`

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -342,7 +342,7 @@ function fetch_all_apis_versions(ctx::KuberContext; override=nothing, verbose::B
             push!(supported, pref_vers_version)
         catch ex
             if isa(ex, KeyError)
-                @info("unsupported $pref_vers")
+                verbose && @info("unsupported $pref_vers")
                 continue
             else
                 rethrow()
@@ -365,7 +365,7 @@ function fetch_all_apis_versions(ctx::KuberContext; override=nothing, verbose::B
                     push!(supported, api_vers.version)
                 end
             catch
-                @info("unsupported $(group_version)")
+                verbose && @info("unsupported $(group_version)")
             end
         end
 


### PR DESCRIPTION
this would avoid printing the logs on kuber init unless verbose is specified

```julia
julia> Kuber.set_api_versions!(ctx)
[ Info: unsupported events.k8s.io/v1
[ Info: unsupported autoscaling/v2
[ Info: unsupported certificates.k8s.io/v1
[ Info: unsupported policy/v1
[ Info: unsupported node.k8s.io/v1
[ Info: unsupported discovery.k8s.io/v1
[ Info: unsupported flowcontrol.apiserver.k8s.io/v1beta2
[ Info: unsupported helm.cattle.io/v1
[ Info: unsupported k3s.cattle.io/v1
```